### PR TITLE
検索ワード数とユーザー数の制限をした

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,12 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     urls_path
   end
+
+  def number_of_keywords
+    number_of_keywords = 0
+    current_user.urls.each do |url|
+      number_of_keywords += url.keywords.count
+    end
+    number_of_keywords
+  end
 end

--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -3,6 +3,7 @@
 class KeywordsController < ApplicationController
   before_action :set_url, only: [:destroy, :new, :create]
   before_action :set_keyword, only: [:destroy]
+  before_action :check_number_of_keywords, only: [:create]
 
   def new
     @keyword = Keyword.new
@@ -33,5 +34,11 @@ class KeywordsController < ApplicationController
 
     def keyword_params
       params.require(:keyword).permit(:keyword)
+    end
+
+    def check_number_of_keywords
+      if number_of_keywords >= 5
+        redirect_to @url, flash: {alert: "検索ワードを追加できませんでした。登録できる検索ワードは合計5個までです。"}
+      end
     end
 end

--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -38,7 +38,7 @@ class KeywordsController < ApplicationController
 
     def check_number_of_keywords
       if number_of_keywords >= 5
-        redirect_to @url, flash: {alert: "検索ワードを追加できませんでした。登録できる検索ワードは合計5個までです。"}
+        redirect_to @url, flash: { alert: "検索ワードを追加できませんでした。登録できる検索ワードは合計5個までです。" }
       end
     end
 end

--- a/app/controllers/urls_controller.rb
+++ b/app/controllers/urls_controller.rb
@@ -2,6 +2,7 @@
 
 class UrlsController < ApplicationController
   before_action :set_url, only: [:show, :destroy]
+  before_action :check_number_of_keywords, only: [:create]
 
   def index
     @urls = current_user.urls.order(created_at: :desc)
@@ -51,5 +52,11 @@ class UrlsController < ApplicationController
       params.require(:url).permit(
         :url,
         keywords_attributes: [:id, :keyword, :_destroy])
+    end
+
+    def check_number_of_keywords
+      if number_of_keywords + url_params[:keywords_attributes].to_h.size > 5
+        redirect_to root_path, flash: { alert: "検索ワードの数が上限を超えた為、URLを登録できませんでした。登録できる検索ワードは合計5個までです。" }
+      end
     end
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :check_number_of_users, only: [:create]
+
+  private
+    def check_number_of_users
+      if User.count >= 60
+        redirect_to root_path, flash: { alert: "既にユーザー数の上限に達している為、アカウント登録できませんでした。" }
+      end
+    end
+
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # devise_for :users
   devise_for :users, controllers: {
     registrations: "users/registrations"
   }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  devise_for :users
+  # devise_for :users
+  devise_for :users, controllers: {
+    registrations: "users/registrations"
+  }
   root "home#index"
   resources :urls, except: [:edit, :update] do
     resources :keywords, only: [:destroy, :new, :create]

--- a/test/fixtures/urls.yml
+++ b/test/fixtures/urls.yml
@@ -42,3 +42,8 @@ url_9:
   id: 9
   url: "https://example.com/index/9"
   user_id: 2
+
+url_10:
+  id: 10
+  url: "https://example.com/index/9"
+  user_id: 3

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -12,3 +12,10 @@ user_2:
   encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
   confirmed_at: <%= Time.now %>
   api_key: user2apikey
+user_3:
+  id: 3
+  name: User_3
+  email: user3@example.com
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
+  confirmed_at: <%= Time.now %>
+  api_key: user3apikey

--- a/test/system/urls_test.rb
+++ b/test/system/urls_test.rb
@@ -3,17 +3,14 @@
 require "application_system_test_case"
 
 class UrlsTest < ApplicationSystemTestCase
-  setup do
-    @user = users(:user_1)
-    login_as @user
-  end
-
   test "URL一覧を表示する" do
+    login_as users(:user_1)
     visit urls_path
     assert_selector "h2", text: "URL一覧"
   end
 
   test "URLを新規登録する" do
+    login_as users(:user_3)
     visit urls_path
     click_on "URL追加"
 
@@ -27,12 +24,14 @@ class UrlsTest < ApplicationSystemTestCase
   end
 
   test "URL詳細画面を表示する" do
+    login_as users(:user_1)
     visit urls_path
     click_on "詳細", match: :first
     assert_selector "h2", text: "URL詳細"
   end
 
   test "URLを削除" do
+    login_as users(:user_1)
     visit urls_path
     click_on "詳細", match: :first
 
@@ -45,6 +44,7 @@ class UrlsTest < ApplicationSystemTestCase
   end
 
   test "検索ワードを削除" do
+    login_as users(:user_1)
     visit urls_path
     click_on "詳細", match: :first
 
@@ -57,6 +57,7 @@ class UrlsTest < ApplicationSystemTestCase
   end
 
   test "検索ワードを追加" do
+    login_as users(:user_3)
     visit urls_path
     click_on "詳細", match: :first
     click_on "検索ワード追加"


### PR DESCRIPTION
## 概要
登録できる検索ワードの数を一人につき５個までにしました。
アカウント登録できるユーザー数を60人までに制限しました。

## 関連Issue
#28 