### PR TITLE
ゲストユーザーのデータを削除・追加するrakeタスクを作成。日付の表示にacquired_onを使うように修正。

### DIFF
--- a/app/controllers/urls_controller.rb
+++ b/app/controllers/urls_controller.rb
@@ -15,7 +15,7 @@ class UrlsController < ApplicationController
     @line_chart_data = @keywords.map do |k|
       h = Hash.new
       k.rankings.each do |r|
-        h[l(r.created_at, format: :short)] = r.rank
+        h[r.acquired_on] = r.rank
       end
       { name: k.keyword, data: h }
     end

--- a/app/views/api/v1/ranks/index.json.jbuilder
+++ b/app/views/api/v1/ranks/index.json.jbuilder
@@ -5,7 +5,7 @@
     url.keywords.each do |k|
       json.set! k.keyword do
         k.rankings.each do |r|
-          json.set! l(r.created_at, format: :short), r.rank
+          json.set! r.acquired_on, r.rank
         end
       end
     end

--- a/app/views/urls/show.html.slim
+++ b/app/views/urls/show.html.slim
@@ -31,9 +31,9 @@ main.page
                   th 日付
                   th 順位
               tbody
-              - k.rankings.order(created_at: :desc).each do |r|
+              - k.rankings.order(acquired_on: :desc).each do |r|
                 tr
-                  td = l r.created_at, format: :short
+                  td = r.acquired_on
                   td = r.rank
 
       - unless @number_of_rank_data == 0

--- a/lib/tasks/rank_bord.rake
+++ b/lib/tasks/rank_bord.rake
@@ -11,7 +11,7 @@ task create_rank: :environment do
 end
 
 desc "ゲストユーザーのURL、検索ワード、ランキングデータを生成"
-task add_guest_data: :environment do
+task create_guest_data: :environment do
   guest_user = User.guest
   8.times do |n|
     url = guest_user.urls.create(url: "https://example.com/#{n+1}")
@@ -25,4 +25,4 @@ task add_guest_data: :environment do
 end
 
 # ゲストユーザーの検索ワードの順位を取得しない為に、create_rankタスクの前にゲストユーザーのデータを一度削除する。
-task routene: [:delete_guest_data, :create_rank, :add_guest_data]
+task routene: [:delete_guest_data, :create_rank, :create_guest_data]

--- a/lib/tasks/rank_bord.rake
+++ b/lib/tasks/rank_bord.rake
@@ -1,6 +1,28 @@
 # frozen_string_literal: true
 
+desc "ゲストユーザーのURL、検索ワード、ランキングデータを全て削除"
+task delete_guest_data: :environment do
+  User.find_by(email: "guest@example.com").urls.destroy_all if User.find_by(email: "guest@example.com")
+end
+
 desc "Google検索順位を保存"
 task create_rank: :environment do
   Keyword.create_rank
 end
+
+desc "ゲストユーザーのURL、検索ワード、ランキングデータを生成"
+task add_guest_data: :environment do
+  guest_user = User.guest
+  8.times do |n|
+    url = guest_user.urls.create(url: "https://example.com/#{n+1}")
+    rand(1..5).times do |v|
+      keyword = url.keywords.create(keyword: "検索ワード#{v+1}")
+      8.times do |k|
+        keyword.rankings.create(rank: rand(1..10), acquired_on: "2020-10-0#{k+1}")
+      end
+    end
+  end
+end
+
+# ゲストユーザーの検索ワードの順位を取得しない為に、create_rankタスクの前にゲストユーザーのデータを一度削除する。
+task routene: [:delete_guest_data, :create_rank, :add_guest_data]


### PR DESCRIPTION
## 概要
- ゲストユーザーのデータを削除・追加するrakeタスクを作成しました。
- ランキングの日付を扱う時にcreated_atを使っていたのですが、acquired_onを使うように修正しました。

## 関連Issue
#85 #86 