### PR TITLE
検索ワード削除ボタンを右に移動

### DIFF
--- a/app/assets/stylesheets/_card.scss
+++ b/app/assets/stylesheets/_card.scss
@@ -15,3 +15,8 @@
   border: solid 1px #1A5084;
   box-shadow: 5px 10px 20px rgba(0,0,0,0.25);
 }
+
+.delete-keyword-btn {
+  position: relative;
+  left: 180px;
+}

--- a/app/views/urls/show.html.slim
+++ b/app/views/urls/show.html.slim
@@ -24,7 +24,7 @@ main.page
                 i.fas.fa-search
               .search-window__keyword
                 = k.keyword
-            p = link_to '削除', url_keyword_path(@url.id, k.id),  method: :delete, data: {   confirm: "検索ワードを削除しますか？" }
+            p = link_to '削除', url_keyword_path(@url.id, k.id),  method: :delete, data: {   confirm: "検索ワードを削除しますか？" }, class: "delete-keyword-btn"
             table.table.table-sm.table-striped
               thead.thead-dark
                 tr


### PR DESCRIPTION
## 概要
検索ワード削除ボタンを右に移動しました。

## Before
![image](https://user-images.githubusercontent.com/53965479/90750048-3a477e80-e30f-11ea-8960-abd5bc022a3d.png)

## After
![image](https://user-images.githubusercontent.com/53965479/90750104-51866c00-e30f-11ea-9d34-d011452dae3c.png)
