### PR TITLE
メール認証で使うgmailを変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -120,8 +120,8 @@ Rails.application.configure do
   ActionMailer::Base.smtp_settings = {
   address: "smtp.gmail.com",
   port: 587,
-  user_name: "rankboard1@gmail.com",
-  password: ENV["RANKBORD1_PWD"],
+  user_name: "info.rankboard@gmail.com",
+  password: ENV["GOOGLE_APPLI_PWD"],
   authentication: "plain",
   enable_starttls_auto: true
   }

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -25,7 +25,7 @@ Devise.setup do |config|
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
   # config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
-  config.mailer_sender = "rankboard1@gmail.com"
+  config.mailer_sender = "info.rankboard@gmail.com"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
## 概要
メール認証で使うgmailを`info.rankboard@gmail.com`に変更しました。

## 関連Issue
#90 